### PR TITLE
Fix for https://issues.jenkins-ci.org/browse/JENKINS-63055

### DIFF
--- a/src/main/resources/com/joelj/jenkins/eztemplates/TemplateImplementationProperty/config.jelly
+++ b/src/main/resources/com/joelj/jenkins/eztemplates/TemplateImplementationProperty/config.jelly
@@ -5,16 +5,16 @@
 
     <f:entry field="templateJobName" title="${%Name of template}">
       <f:select/>
-      <f:description>
-        <j:if test="${instance.templateJobName != null}">
-          <j:set var="template" value="${instance.findTemplate()}"/>
-          <j:if test="${template != null}">
-            ${%Currently based on}:
-            <a href="${rootURL}/${template.url}">${template.fullDisplayName}</a>
-          </j:if>
-        </j:if>
-      </f:description>
     </f:entry>
+    <f:description>
+      <j:if test="${instance.templateJobName != null}">
+        <j:set var="template" value="${instance.findTemplate()}"/>
+        <j:if test="${template != null}">
+          ${%Currently based on}:
+          <a href="${rootURL}/${template.url}">${template.fullDisplayName}</a>
+        </j:if>
+      </j:if>
+    </f:description>
 
     <f:advanced>
       <f:entry>


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-63055

We found that the cause of the issue appears to be the use of an additional jelly tag (in this case f:description) within the drop down f:entry tag.  This prevented the creation of the <td class=“setting-no-help”></td> tag which in turn caused the drop down refresh to fail (as the setting-main tag now requires a sibling).

Simply moving the f:description jelly tag outside the f:entry tag fixed the issue.