### PR TITLE
Add ability to ignore build discard strategy

### DIFF
--- a/src/main/java/com/joelj/jenkins/eztemplates/exclusion/DiscardExclusion.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/exclusion/DiscardExclusion.java
@@ -1,0 +1,41 @@
+package com.joelj.jenkins.eztemplates.exclusion;
+
+import com.google.common.base.Throwables;
+import hudson.model.AbstractProject;
+import hudson.model.Label;
+import jenkins.model.BuildDiscarder;
+
+import java.io.IOException;
+
+public class DiscardExclusion extends AbstractExclusion {
+
+    public static final String ID = "discard-label";
+    private static final String DESCRIPTION = "Retain Discard Strategy";
+
+    public DiscardExclusion() {
+        super(ID, DESCRIPTION);
+    }
+
+    @Override
+    public String getDisabledText() {
+        return null;
+    }
+
+    @Override
+    public void preClone(EzContext context, AbstractProject implementationProject) {
+        if (!context.isSelected()) return;
+        context.record(implementationProject.getBuildDiscarder());
+    }
+
+    @Override
+    public void postClone(EzContext context, AbstractProject implementationProject) {
+        if (!context.isSelected()) return;
+        BuildDiscarder rot = context.remember();
+        try {
+            implementationProject.setBuildDiscarder(rot);
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+}

--- a/src/main/java/com/joelj/jenkins/eztemplates/exclusion/Exclusions.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/exclusion/Exclusions.java
@@ -25,6 +25,7 @@ public class Exclusions {
     static {
         ImmutableList.Builder<Exclusion> builder = ImmutableList.builder();
         builder.add(new EzTemplatesExclusion());
+		builder.add(new DiscardExclusion());
         builder.add(new JobParametersExclusion());
         builder.add(new TriggersExclusion());
         builder.add(new DisabledExclusion());


### PR DESCRIPTION
I find the EZ template very useful but often have needs to keep different numbers of builds for different implementations of the template.  Like a dev and a release build based on the same template where release is kept for ever and dev is kept like the last 5 builds.  Maybe useful to others. 