### PR TITLE
Stop setting `pluginFirstClassLoader`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ jenkinsPlugin {
     gitHubUrl = 'https://github.com/jenkinsci/ez-templates-plugin.git'
 
     // use the plugin class loader before the core class loader, defaults to false
-    pluginFirstClassLoader = true
+    pluginFirstClassLoader = false
 
     developers {
         developer {


### PR DESCRIPTION
This setting is explicitly not recommended, and this plugin doesn't need it because it doesn't bundle any libraries.